### PR TITLE
Add error banners for connectivity failures

### DIFF
--- a/eWonicApp/ContentView.swift
+++ b/eWonicApp/ContentView.swift
@@ -62,6 +62,8 @@ struct ContentView: View {
           view_model.multipeerSession.disconnect()
           view_model.sttService.stop()
         }
+
+        ErrorBanner(message: $view_model.errorMessage)
       }
       .navigationBarHidden(true)
     }
@@ -349,6 +351,34 @@ private struct PeerDiscoveryView: View {
     .background(Color.white.opacity(0.05),
                 in: RoundedRectangle(cornerRadius: 14))
     .foregroundColor(.white)
+  }
+}
+
+private struct ErrorBanner: View {
+  @Binding var message: String?
+  var body: some View {
+    if let msg = message {
+      VStack {
+        Spacer()
+        HStack(alignment: .top, spacing: 8) {
+          Image(systemName: "exclamationmark.triangle.fill")
+            .foregroundColor(.white)
+          Text(msg)
+            .font(.subheadline)
+            .foregroundColor(.white)
+            .multilineTextAlignment(.leading)
+          Spacer(minLength: 4)
+          Button(action: { withAnimation { message = nil } }) {
+            Image(systemName: "xmark.circle.fill")
+              .foregroundColor(.white)
+          }
+        }
+        .padding()
+        .background(Color.red.opacity(0.95), in: RoundedRectangle(cornerRadius: 14))
+        .padding()
+      }
+      .transition(.move(edge: .bottom).combined(with: .opacity))
+    }
   }
 }
 

--- a/eWonicApp/TranslationViewModel.swift
+++ b/eWonicApp/TranslationViewModel.swift
@@ -27,6 +27,7 @@ final class TranslationViewModel: ObservableObject {
   @Published var isProcessing            = false
   @Published var permissionStatusMessage = "Checking permissions…"
   @Published var hasAllPermissions       = false
+  @Published var errorMessage: String?
 
   // ─────────────────────────────── Languages
   @Published var myLanguage   = "en-US" { didSet { refreshVoices() } }
@@ -72,6 +73,14 @@ final class TranslationViewModel: ObservableObject {
     wireConnectionBadge()
     wirePipelines()
     wireMicPauseDuringPlayback()
+    multipeerSession.errorSubject
+      .receive(on: RunLoop.main)
+      .sink { [weak self] msg in self?.errorMessage = msg }
+      .store(in: &cancellables)
+    (sttService as! AzureSpeechTranslationService).errorSubject
+      .receive(on: RunLoop.main)
+      .sink { [weak self] msg in self?.errorMessage = msg }
+      .store(in: &cancellables)
     multipeerSession.onMessageReceived = { [weak self] m in
       self?.handleReceivedMessage(m)
     }


### PR DESCRIPTION
## Summary
- display a red banner for any runtime errors
- report connection and send failures from `MultipeerSession`
- surface Azure translation errors with more detail
- wire error outputs into `TranslationViewModel`

## Testing
- `swift test` *(fails: Package.swift missing)*

------
https://chatgpt.com/codex/tasks/task_e_685980e4cbe4832c8cd984c81658c1d1