### PR TITLE
Fix multipeer background publish warning

### DIFF
--- a/eWonicApp/AzureSpeechTranslationService.swift
+++ b/eWonicApp/AzureSpeechTranslationService.swift
@@ -172,8 +172,11 @@ final class AzureSpeechTranslationService: NSObject, ObservableObject {
     recognizer!.addCanceledEventHandler { [weak self] _, ev in
       guard let self else { return }
       let wasListening = self.isListening
-      self.recognizer  = nil
-      self.isListening = false
+      DispatchQueue.main.async { [weak self] in
+        guard let self else { return }
+        self.recognizer  = nil
+        self.isListening = false
+      }
       var msg = "Azure cancelled (\(ev.errorCode.rawValue)): \(ev.errorDetails)"
         if ev.errorDetails!.lowercased().contains("network") ||
             ev.errorDetails!.lowercased().contains("internet") {


### PR DESCRIPTION
## Summary
- avoid publishing Azure recognizer state from a background thread

## Testing
- `swift test -v` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a1fe52f18832cab4cb586b157bb29