### PR TITLE
feat: add mic and playback sliders

### DIFF
--- a/eWonicApp/AudioSessionManager.swift
+++ b/eWonicApp/AudioSessionManager.swift
@@ -66,4 +66,17 @@ final class AudioSessionManager {
             }
         }
     }
+
+    /// Adjust microphone sensitivity (0.0 – 1.0).
+    func setInputGain(_ value: Float) {
+        let clamped = max(0, min(1, value))
+        guard session.isInputGainSettable else { return }
+        do {
+            try session.setInputGain(clamped)
+        } catch {
+            let msg = "Mic gain failed: \(error.localizedDescription)"
+            print("❌ \(msg)")
+            errorSubject.send(msg)
+        }
+    }
 }

--- a/eWonicApp/ContentView.swift
+++ b/eWonicApp/ContentView.swift
@@ -41,6 +41,9 @@ struct ContentView: View {
                                 peer_text: view_model.peerSaidText,
                                 translated: view_model.translatedTextForMeToHear)
 
+            Settings_sliders(mic: $view_model.micSensitivity,
+                               speed: $view_model.playbackSpeed)
+
             Record_button(is_listening:  view_model.sttService.isListening,
                           is_processing: view_model.isProcessing,
                           start_action:  view_model.startListening,
@@ -251,6 +254,29 @@ private struct Bubble: View {
         .frame(maxWidth: .infinity,
                alignment: align == .leading ? .leading : .trailing)
         .foregroundColor(.white)
+    }
+  }
+}
+
+private struct Settings_sliders: View {
+  @Binding var mic: Double
+  @Binding var speed: Double
+  var body: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      VStack(alignment: .leading) {
+        Text("Mic Sensitivity")
+          .font(.caption)
+          .foregroundColor(.white.opacity(0.7))
+        Slider(value: $mic, in: 0...1)
+          .tint(EwonicTheme.accent)
+      }
+      VStack(alignment: .leading) {
+        Text("Playback Speed")
+          .font(.caption)
+          .foregroundColor(.white.opacity(0.7))
+        Slider(value: $speed, in: 0...1)
+          .tint(EwonicTheme.accent)
+      }
     }
   }
 }

--- a/eWonicApp/TranslationViewModel.swift
+++ b/eWonicApp/TranslationViewModel.swift
@@ -61,6 +61,14 @@ final class TranslationViewModel: ObservableObject {
   /// languageCode → chosen voice identifier
   @Published var voice_for_lang: [String:String] = [:]
 
+  // ─────────────────────────────── Settings
+  @Published var micSensitivity: Double = 0.5 {
+    didSet { AudioSessionManager.shared.setInputGain(Float(micSensitivity)) }
+  }
+  @Published var playbackSpeed: Double = 0.55 {
+    didSet { ttsService.speech_rate = Float(playbackSpeed) }
+  }
+
   // ─────────────────────────────── Internals
   private var cancellables            = Set<AnyCancellable>()
   private var lastReceivedTimestamp   : TimeInterval = 0
@@ -73,7 +81,9 @@ final class TranslationViewModel: ObservableObject {
     wireConnectionBadge()
     wirePipelines()
     wireMicPauseDuringPlayback()
-      
+    AudioSessionManager.shared.setInputGain(Float(micSensitivity))
+    ttsService.speech_rate = Float(playbackSpeed)
+
       // Whenever the user changes voice_for_lang, push it into AppleTTSService
       $voice_for_lang
         .receive(on: RunLoop.main)


### PR DESCRIPTION
## Summary
- add mic sensitivity and playback speed sliders to translation screen
- wire view model settings to adjust AVAudioSession input gain and TTS speech rate
- expose helper for mic input gain on AudioSessionManager

## Testing
- `xcodebuild -workspace eWonicApp.xcworkspace -scheme eWonicApp -destination 'platform=iOS Simulator,name=iPhone 14' test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893bf3ea9e8832cad38ad3fee384384