### PR TITLE
Enable multi-peer translation lobby with per-device language settings

### DIFF
--- a/eWonicApp/ContentView.swift
+++ b/eWonicApp/ContentView.swift
@@ -27,12 +27,11 @@ struct ContentView: View {
               view_model.checkAllPermissions()
             }
 
-          } else if view_model.multipeerSession.connectionState == .connected {
+          } else if !view_model.multipeerSession.connectedPeers.isEmpty {
 
-            Language_bar(my_lang:   $view_model.myLanguage,
-                         peer_lang: $view_model.peerLanguage,
-                         list:      view_model.availableLanguages,
-                         disabled:  view_model.isProcessing || view_model.sttService.isListening)
+            Language_bar(my_lang: $view_model.myLanguage,
+                         list:    view_model.availableLanguages,
+                         disabled: view_model.isProcessing || view_model.sttService.isListening)
 
               Voice_bar(voice_for_lang: $view_model.voice_for_lang,
                         voices:        view_model.availableVoices)
@@ -129,18 +128,12 @@ private struct Permission_card: View {
 
 private struct Language_bar: View {
   @Binding var my_lang: String
-  @Binding var peer_lang: String
   let list: [TranslationViewModel.Language]
   let disabled: Bool
   var body: some View {
-    HStack(spacing: 12) {
-      Lang_menu(label: "I Speak", code: $my_lang, list: list)
-      Image(systemName: "arrow.left.arrow.right")
-        .foregroundColor(.white.opacity(disabled ? 0.35 : 1))
-      Lang_menu(label: "Peer Hears", code: $peer_lang, list: list)
-    }
-    .disabled(disabled)
-    .opacity(disabled ? 0.55 : 1)
+    Lang_menu(label: "I Speak", code: $my_lang, list: list)
+      .disabled(disabled)
+      .opacity(disabled ? 0.55 : 1)
   }
 }
 

--- a/eWonicApp/MessageData.swift
+++ b/eWonicApp/MessageData.swift
@@ -9,9 +9,9 @@ import Foundation
 
 struct MessageData: Codable {
     let id: UUID
+    let senderID: String
     let originalText: String
     let sourceLanguageCode: String // e.g., "en-US" (BCP-47)
-    let targetLanguageCode: String // e.g., "es-ES" (BCP-47)
     let isFinal: Bool            // true if final transcript
     let timestamp: TimeInterval
 }

--- a/eWonicApp/MultipeerSession.swift
+++ b/eWonicApp/MultipeerSession.swift
@@ -23,6 +23,8 @@ final class MultipeerSession: NSObject, ObservableObject {
   // ────────────────────────────── MC plumbing
   private let myPeerID = MCPeerID(displayName: UIDevice.current.name)
 
+  var localPeerID: MCPeerID { myPeerID }
+
   private lazy var session: MCSession = {
     let s = MCSession(
       peer:               myPeerID,
@@ -165,7 +167,7 @@ extension MultipeerSession: MCSessionDelegate {
     case .notConnected:
       DispatchQueue.main.async {
         self.connectedPeers.removeAll { $0 == id }
-        self.connectionState = .notConnected
+        self.connectionState = self.connectedPeers.isEmpty ? .notConnected : .connected
       }
       log.debug("[Multipeer] \(id.displayName) DISCONNECTED")
       errorSubject.send("Peer \(id.displayName) disconnected")

--- a/eWonicApp/UnifiedTranslateService.swift
+++ b/eWonicApp/UnifiedTranslateService.swift
@@ -1,21 +1,36 @@
-//
-//  UnifiedTranslateService.swift
-//  eWonicApp
-//
-//  Single source of truth for sentence-level translation.
-//  **Azure-only – no fallbacks.**
-//
+import Foundation
 
-//import Foundation
-//
-//struct UnifiedTranslateService {
-//
-//  /// Translate *text* from **src** → **dst** via Azure Text Translator
-//  static func translate(_ text: String,
-//                        from src: String,
-//                        to   dst: String) async throws -> String {
-//    return try await AzureTextTranslator.translate(text,
-//                                                   from: src,
-//                                                   to:   dst)
-//  }
-//}
+struct UnifiedTranslateService {
+  /// Translate text from src → dst using Azure Text Translator
+  static func translate(_ text: String,
+                        from src: String,
+                        to dst: String) async throws -> String {
+    let key    = (Bundle.main.object(forInfoDictionaryKey: "AZ_KEY") as? String ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+    let region = (Bundle.main.object(forInfoDictionaryKey: "AZ_REGION") as? String ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+
+    let from = src.split(separator: "-").first ?? Substring(src)
+    let to   = dst.split(separator: "-").first ?? Substring(dst)
+
+    var comps = URLComponents(string: "https://api.cognitive.microsofttranslator.com/translate")!
+    comps.queryItems = [
+      URLQueryItem(name: "api-version", value: "3.0"),
+      URLQueryItem(name: "from", value: String(from)),
+      URLQueryItem(name: "to",   value: String(to))
+    ]
+    var req = URLRequest(url: comps.url!)
+    req.httpMethod = "POST"
+    req.addValue(key,    forHTTPHeaderField: "Ocp-Apim-Subscription-Key")
+    req.addValue(region, forHTTPHeaderField: "Ocp-Apim-Subscription-Region")
+    req.addValue("application/json", forHTTPHeaderField: "Content-Type")
+    let body = [["Text": text]]
+    req.httpBody = try JSONEncoder().encode(body)
+
+    let (data, _) = try await URLSession.shared.data(for: req)
+    struct TranslationResponse: Codable {
+      struct Translation: Codable { let text: String }
+      let translations: [Translation]
+    }
+    let decoded = try JSONDecoder().decode([TranslationResponse].self, from: data)
+    return decoded.first?.translations.first?.text ?? text
+  }
+}


### PR DESCRIPTION
## Summary
- allow messages to include sender and language metadata
- expose local peer ID and support multiple peer connections
- translate incoming text locally per user language via new Azure-powered service
- simplify UI to select only your language and voice

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68af73a2583c832ca359f77e72547975