### PR TITLE
Broadcast speaker language and support multi-peer translation

### DIFF
--- a/eWonicApp/MessageData.swift
+++ b/eWonicApp/MessageData.swift
@@ -10,8 +10,8 @@ import Foundation
 struct MessageData: Codable {
     let id: UUID
     let originalText: String
-    let sourceLanguageCode: String // e.g., "en-US" (BCP-47)
-    let targetLanguageCode: String // e.g., "es-ES" (BCP-47)
+    let sourceLanguageCode: String // Speaker's language, e.g., "en-US" (BCP-47)
+    let targetLanguageCode: String? // Optional; unused when broadcasting to many peers
     let isFinal: Bool            // true if final transcript
     let timestamp: TimeInterval
 }


### PR DESCRIPTION
## Summary
- advertise each device's language in multipeer discovery and track up to 6 peers
- send transcripts with speaker language and translate on receipt for each device
- allow messages to omit a fixed target language for multi-language sessions

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4e8000a7c832cbc7b7c4713d7f8bd