### PR TITLE
M1 — TurnContext + PhraseQueue (One-Phone)

### DIFF
--- a/eWonicApp/AppleTTSService.swift
+++ b/eWonicApp/AppleTTSService.swift
@@ -29,6 +29,7 @@ final class AppleTTSService: NSObject, ObservableObject {
 
   @Published var isSpeaking = false
   let finishedSubject = PassthroughSubject<Void, Never>()
+  let startedSubject  = PassthroughSubject<Void, Never>()
 
   /// Map languageCode → preferred AVSpeech voice identifier
   private var preferred_voices: [String: String] = [:]
@@ -105,6 +106,10 @@ final class AppleTTSService: NSObject, ObservableObject {
     isSpeaking = false
   }
 
+  func stopAtBoundary() {
+    synthesizer.stopSpeaking(at: .word)
+  }
+
   // ─────────────────────────────────────────────
   // MARK: – Private helpers
   // ─────────────────────────────────────────────
@@ -179,6 +184,11 @@ private func clamp<T: Comparable>(_ value: T, min lower: T, max upper: T) -> T {
 // ─────────────────────────────────────────────
 
 extension AppleTTSService: AVSpeechSynthesizerDelegate {
+  func speechSynthesizer(_ s: AVSpeechSynthesizer, didStart _: AVSpeechUtterance) {
+    isSpeaking = true
+    startedSubject.send(())
+  }
+
   func speechSynthesizer(_ s: AVSpeechSynthesizer, didFinish _: AVSpeechUtterance) {
     isSpeaking = false
     AudioSessionManager.shared.end()

--- a/eWonicApp/TurnContext.swift
+++ b/eWonicApp/TurnContext.swift
@@ -1,0 +1,118 @@
+import Foundation
+
+struct LangVotes {
+  private(set) var englishScore: Double = 0
+  private(set) var spanishScore: Double = 0
+  private var lastUpdate: Date = Date()
+  private let decayHalfLife: TimeInterval = 2.8
+
+  private let englishStopwords: Set<String> = [
+    "the","and","to","of","a","in","that","it","is","you","for","on","with","as","have","be","at","or","this","but"
+  ]
+
+  private let spanishStopwords: Set<String> = [
+    "el","la","y","de","que","en","a","los","se","del","las","por","un","para","con","no","una","su","al","lo"
+  ]
+
+  mutating func observe(text: String, now: Date = Date()) {
+    applyDecay(now: now)
+    guard !text.isEmpty else { return }
+
+    let tokens = LangVotes.tokens(in: text)
+    if tokens.isEmpty { return }
+
+    let englishHits = tokens.filter { englishStopwords.contains($0) }.count
+    let spanishHits = tokens.filter { spanishStopwords.contains($0) }.count
+
+    let accented = text.reduce(into: 0) { partial, char in
+      if "áéíóúñÁÉÍÓÚÑ".contains(char) { partial += 1 }
+    }
+
+    englishScore += Double(englishHits) * 1.2 + Double(tokens.count - englishHits) * 0.05
+    spanishScore += Double(spanishHits) * 1.2 + Double(tokens.count - spanishHits) * 0.05
+    spanishScore += Double(accented) * 0.6
+
+    lastUpdate = now
+  }
+
+  mutating func biasToward(base: String, weight: Double = 0.3) {
+    if base.lowercased().hasPrefix("en") {
+      englishScore += weight
+    } else if base.lowercased().hasPrefix("es") {
+      spanishScore += weight
+    }
+  }
+
+  private mutating func applyDecay(now: Date) {
+    let dt = now.timeIntervalSince(lastUpdate)
+    guard dt > 0 else { return }
+    let decay = exp(-dt / decayHalfLife)
+    englishScore *= decay
+    spanishScore *= decay
+    lastUpdate = now
+  }
+
+  var leadingBase: String? {
+    if englishScore == 0 && spanishScore == 0 { return nil }
+    return englishScore >= spanishScore ? "en" : "es"
+  }
+
+  var confidence: Double {
+    let total = englishScore + spanishScore
+    guard total > 0 else { return 0 }
+    return abs(englishScore - spanishScore) / total
+  }
+
+  static func tokens(in text: String) -> [String] {
+    text.lowercased()
+      .components(separatedBy: CharacterSet.alphanumerics.inverted)
+      .filter { !$0.isEmpty }
+  }
+}
+
+struct TurnContext {
+  var rollingText: String = ""
+  var lockedSrcBase: String?
+  var votes = LangVotes()
+  let startedAt: Date
+  var lastGrowthAt: Date
+  var committed: Bool = false
+  var flipUsed: Bool = false
+
+  mutating func update(with partial: String, now: Date = Date()) {
+    guard partial != rollingText else { return }
+    rollingText = partial
+    votes.observe(text: partial, now: now)
+    lastGrowthAt = now
+  }
+
+  mutating func lock(base: String) {
+    lockedSrcBase = base
+  }
+
+  func shouldDelayForTrailingConjunction() -> Bool {
+    guard !rollingText.isEmpty else { return false }
+    let tokens = LangVotes.tokens(in: rollingText)
+    guard let last = tokens.last else { return false }
+    let delayWords: Set<String> = ["and","y","que","then","so","pero"]
+    return delayWords.contains(last)
+  }
+
+  func decidedBase(defaultBase: String) -> (String, Double) {
+    if let locked = lockedSrcBase { return (locked, 1.0) }
+    if let leading = votes.leadingBase {
+      return (leading, max(votes.confidence, 0.5))
+    }
+    return (defaultBase, 0.4)
+  }
+}
+
+struct PhraseCommit: Identifiable {
+  let id = UUID()
+  let srcFull: String
+  let dstFull: String
+  let raw: String
+  let committedAt: TimeInterval
+  let decidedAt: TimeInterval
+  let confidence: Double
+}


### PR DESCRIPTION
## Summary
- add TurnContext, LangVotes, and PhraseCommit data structures for One-Phone phrase tracking
- extend the native STT service to publish timestamped partials and stability boundaries that feed the phrase commit logic
- implement per-phrase language locking, FIFO phrase queue draining, telemetry breadcrumbs, and haptic hooks in TranslationViewModel
- add TTS start notifications and boundary stops so queued phrases can barge in cleanly

## Testing
- `xcodebuild -workspace eWonicApp.xcworkspace -scheme eWonicApp -sdk iphonesimulator -configuration Debug build` *(fails: `xcodebuild` unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dc0c9898a8832cab2a8bba8a232bd3